### PR TITLE
fix: resolve 401 Invalid Credentials from Choreo staging gateway

### DIFF
--- a/webapp/src/utils/apiService.ts
+++ b/webapp/src/utils/apiService.ts
@@ -13,7 +13,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import axios, {
   AxiosInstance,
   AxiosRequestConfig,
@@ -44,7 +43,7 @@ export class APIService {
 
   constructor(idToken: string, callback: () => Promise<{ accessToken: string }>) {
     APIService._instance = axios.create({
-      baseURL: ServiceBaseUrl, 
+      baseURL: ServiceBaseUrl,
     });
     rax.attach(APIService._instance);
 
@@ -151,11 +150,12 @@ export class APIService {
           typeof (config.headers as { set?: (k: string, v: string) => void }).set === "function"
         ) {
           (config.headers as { set: (k: string, v: string) => void }).set(
-            "x-jwt-assertion",
-            APIService._idToken,
+            "Authorization",
+            `Bearer ${APIService._idToken}`,
           );
         } else {
-          (config.headers as Record<string, string>)["x-jwt-assertion"] = APIService._idToken;
+          (config.headers as Record<string, string>)["Authorization"] =
+            `Bearer ${APIService._idToken}`;
         }
 
         const endpointKey = [


### PR DESCRIPTION
### Summary
API calls from the dashboard to the Choreo-hosted backend were failing on staging with `401 Unauthorized – 900901 Invalid Credentials`. The frontend was sending the OAuth2 access token under `x-jwt-assertion` instead of the standard `Authorization: Bearer <token>` header.

### Root Cause
`x-jwt-assertion` is an **internal, upstream-side** header that Choreo's API gateway injects into the request *after* it has validated the caller's Bearer token. It is not a header the gateway itself validates.

Because the frontend was only setting `x-jwt-assertion` and never `Authorization`, the Choreo gateway saw the request as unauthenticated and rejected it before it ever reached the Ballerina backend. The access token itself (audience, scopes, expiry) was valid — it just never got a chance to be validated.

### Fix
Updated the Axios request interceptor in [webapp/src/utils/apiService.ts](cci:7://file:///Users/atheeque/Desktop/expense-management-app/webapp/src/utils/apiService.ts:0:0-0:0) to attach the access token as:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated API authentication headers to use standard Authorization Bearer token format instead of custom header format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->