### PR TITLE
Resolve Malformed Invoker info 500 error by replacing cloneWithType with safe JWT claim extraction

### DIFF
--- a/backend/modules/authorization/authorization.bal
+++ b/backend/modules/authorization/authorization.bal
@@ -33,7 +33,7 @@ public isolated service class JwtInterceptor {
         returns http:NextService|http:Forbidden|http:InternalServerError|error? {
 
         string|error idToken = req.getHeader(JWT_ASSERTION_HEADER);
-        
+
         if idToken is error {
             string errorMsg = "Missing invoker info header!";
             log:printError(errorMsg, idToken);
@@ -58,10 +58,14 @@ public isolated service class JwtInterceptor {
             return <http:InternalServerError>{body: {message: errorMsg}};
         }
 
-        string[] groupsList = userInfo.groups is string[] ? <string[]>userInfo.groups : [<string>userInfo.groups];
+        string|string[] groups = userInfo.groups;
+        UserInfo userInfoHeader = {
+            email: userInfo.email,
+            groups: groups is string[] ? groups : [groups]
+        };
         foreach anydata role in authorizedRoles.toArray() {
-            if groupsList.some(r => r === role) {
-                ctx.set(HEADER_USER_INFO, userInfo);
+            if userInfoHeader.groups.some(r => r === role) {
+                ctx.set(HEADER_USER_INFO, userInfoHeader);
                 return ctx.next();
             }
         }

--- a/backend/modules/authorization/authorization.bal
+++ b/backend/modules/authorization/authorization.bal
@@ -50,12 +50,39 @@ public isolated service class JwtInterceptor {
             return <http:InternalServerError>{body: {message: errorMsg}};
         }
 
-        CustomJwtPayload|error userInfo = result[1].cloneWithType(CustomJwtPayload);
-        if userInfo is error {
+        // Convert the decoded payload to a plain JSON map so custom claims
+        // (email, groups) are accessed as json rather than anydata, avoiding
+        // cloneWithType failures when groups is a json[] or absent.
+        json payloadJson = result[1].toJson();
+        if payloadJson !is map<json> {
             string errorMsg = "Malformed Invoker info object!";
-            log:printError(errorMsg, userInfo);
+            log:printError(errorMsg + ": JWT payload is not a JSON object");
             return <http:InternalServerError>{body: {message: errorMsg}};
         }
+        map<json> claims = payloadJson;
+
+        // email is required
+        json emailClaim = claims["email"];
+        if emailClaim !is string {
+            string errorMsg = "Malformed Invoker info object!";
+            log:printError(errorMsg + ": 'email' claim missing or not a string");
+            return <http:InternalServerError>{body: {message: errorMsg}};
+        }
+
+        // groups may be a json array, a bare string, or absent — handle all cases
+        string[] groups = [];
+        json groupsClaim = claims["groups"];
+        if groupsClaim is json[] {
+            foreach json g in groupsClaim {
+                if g is string {
+                    groups.push(g);
+                }
+            }
+        } else if groupsClaim is string {
+            groups = [groupsClaim];
+        }
+
+        CustomJwtPayload userInfo = {email: emailClaim, groups: groups};
 
         foreach anydata role in authorizedRoles.toArray() {
             if userInfo.groups.some(r => r === role) {

--- a/backend/modules/authorization/authorization.bal
+++ b/backend/modules/authorization/authorization.bal
@@ -33,6 +33,7 @@ public isolated service class JwtInterceptor {
         returns http:NextService|http:Forbidden|http:InternalServerError|error? {
 
         string|error idToken = req.getHeader(JWT_ASSERTION_HEADER);
+        
         if idToken is error {
             string errorMsg = "Missing invoker info header!";
             log:printError(errorMsg, idToken);
@@ -50,42 +51,16 @@ public isolated service class JwtInterceptor {
             return <http:InternalServerError>{body: {message: errorMsg}};
         }
 
-        // Convert the decoded payload to a plain JSON map so custom claims
-        // (email, groups) are accessed as json rather than anydata, avoiding
-        // cloneWithType failures when groups is a json[] or absent.
-        json payloadJson = result[1].toJson();
-        if payloadJson !is map<json> {
+        CustomJwtPayload|error userInfo = result[1].cloneWithType(CustomJwtPayload);
+        if userInfo is error {
             string errorMsg = "Malformed Invoker info object!";
-            log:printError(errorMsg + ": JWT payload is not a JSON object");
-            return <http:InternalServerError>{body: {message: errorMsg}};
-        }
-        map<json> claims = payloadJson;
-
-        // email is required
-        json emailClaim = claims["email"];
-        if emailClaim !is string {
-            string errorMsg = "Malformed Invoker info object!";
-            log:printError(errorMsg + ": 'email' claim missing or not a string");
+            log:printError(errorMsg, userInfo);
             return <http:InternalServerError>{body: {message: errorMsg}};
         }
 
-        // groups may be a json array, a bare string, or absent — handle all cases
-        string[] groups = [];
-        json groupsClaim = claims["groups"];
-        if groupsClaim is json[] {
-            foreach json g in groupsClaim {
-                if g is string {
-                    groups.push(g);
-                }
-            }
-        } else if groupsClaim is string {
-            groups = [groupsClaim];
-        }
-
-        CustomJwtPayload userInfo = {email: emailClaim, groups: groups};
-
+        string[] groupsList = userInfo.groups is string[] ? <string[]>userInfo.groups : [<string>userInfo.groups];
         foreach anydata role in authorizedRoles.toArray() {
-            if userInfo.groups.some(r => r === role) {
+            if groupsList.some(r => r === role) {
                 ctx.set(HEADER_USER_INFO, userInfo);
                 return ctx.next();
             }

--- a/backend/modules/authorization/types.bal
+++ b/backend/modules/authorization/types.bal
@@ -19,7 +19,7 @@ public type CustomJwtPayload record {
     # Work email address of the authenticated user.
     string email;
     # Group or role names assigned to the authenticated user.
-    string[] groups = [];
+    string|string[] groups = [];
 };
 
 # Application-specific role names used for authorization checks.

--- a/backend/modules/authorization/types.bal
+++ b/backend/modules/authorization/types.bal
@@ -16,16 +16,24 @@
 
 # User information extracted from the Asgardeo JWT assertion.
 public type CustomJwtPayload record {
-    # Work email address of the authenticated user.
+    # Work email address of the authenticated user
     string email;
-    # Group or role names assigned to the authenticated user.
+    # Group or role names assigned to the authenticated user
     string|string[] groups = [];
 };
 
+# Normalized user information stored in the request context after JWT validation.
+public type UserInfo record {|
+    # Work email address of the authenticated user
+    string email;
+    # Normalized group names assigned to the authenticated user
+    string[] groups = [];
+|};
+
 # Application-specific role names used for authorization checks.
 public type AppRoles record {|
-    # Role granted to employees.
+    # Role granted to employees
     string employeeRole;
-    # Role granted to finance administrators.
+    # Role granted to finance administrators
     string financeAdminRole;
 |};

--- a/backend/modules/authorization/types.bal
+++ b/backend/modules/authorization/types.bal
@@ -19,7 +19,7 @@ public type CustomJwtPayload record {
     # Work email address of the authenticated user.
     string email;
     # Group or role names assigned to the authenticated user.
-    string[] groups;
+    string[] groups = [];
 };
 
 # Application-specific role names used for authorization checks.

--- a/backend/modules/database/types.bal
+++ b/backend/modules/database/types.bal
@@ -26,42 +26,42 @@ public enum OpdClaimStatus {
 
 # Configurable database connection settings.
 public type DatabaseConfig record {|
-    # Host name or IP address of the database server.
+    # Host name or IP address of the database server
     string host;
-    # User name used to connect to the database.
+    # User name used to connect to the database
     string user;
-    # Password used to connect to the database.
+    # Password used to connect to the database
     string password;
-    # Name of the target database schema.
+    # Name of the target database schema
     string database;
-    # Port used by the database server.
+    # Port used by the database server
     int port = 3306;
-    # Connection pool settings for the database client.
+    # Connection pool settings for the database client
     sql:ConnectionPool connectionPool = {};
 |};
 
 # Query result containing a single aggregated decimal total.
 public type AmountRow record {|
-    # Aggregated total amount returned by the query.
+    # Aggregated total amount returned by the query
     decimal total;
 |};
 
 # Query result containing a single aggregated count.
 public type CountRow record {|
-    # Aggregated count returned by the query.
+    # Aggregated count returned by the query
     int count;
 |};
 
 # Query result containing an employee email.
 public type EmployeeEmailRow record {|
-    # Employee work email associated with a claim.
+    # Employee work email associated with a claim
     string employeeEmail;
 |};
 
 # Query result containing a claim total for an employee.
 public type EmployeeTotalRow record {|
-    # Employee work email associated with the total.
+    # Employee work email associated with the total
     string employeeEmail;
-    # Total claim amount calculated for the employee.
+    # Total claim amount calculated for the employee
     decimal totalAmount;
 |};

--- a/backend/service.bal
+++ b/backend/service.bal
@@ -104,11 +104,12 @@ service http:InterceptableService / on new http:Listener(9090) {
             };
         }
 
+        string[] groupsList = userInfo.groups is string[] ? <string[]>userInfo.groups : [<string>userInfo.groups];
         int[] privileges = [];
-        if authorization:checkPermissions([authorization:authorizedRoles.employeeRole], userInfo.groups) {
+        if authorization:checkPermissions([authorization:authorizedRoles.employeeRole], groupsList) {
             privileges.push(authorization:EMPLOYEE_ROLE_PRIVILEGE);
         }
-        if authorization:checkPermissions([authorization:authorizedRoles.financeAdminRole], userInfo.groups) {
+        if authorization:checkPermissions([authorization:authorizedRoles.financeAdminRole], groupsList) {
             privileges.push(authorization:FINANCE_ADMIN_PRIVILEGE);
         }
 
@@ -172,9 +173,9 @@ service http:InterceptableService / on new http:Listener(9090) {
         int effectiveMonth = month ?: civilTime.month;
 
         OpdClaimSummaryResponse|error summary = getOpdClaimSummary(
-            effectiveYear,
-            effectiveMonth,
-            months
+                effectiveYear,
+                effectiveMonth,
+                months
         );
         if summary is error {
             string customError = "Failed to build OPD claim summary.";

--- a/backend/service.bal
+++ b/backend/service.bal
@@ -77,7 +77,7 @@ service http:InterceptableService / on new http:Listener(9090) {
     # + ctx - Request context containing authenticated user information
     # + return - User information response if successful, otherwise an internal server error
     resource function get user\-info(http:RequestContext ctx) returns UserInfoResponse|http:InternalServerError {
-        authorization:CustomJwtPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        authorization:UserInfo|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
         if userInfo is error {
             return <http:InternalServerError>{
                 body: {
@@ -104,12 +104,11 @@ service http:InterceptableService / on new http:Listener(9090) {
             };
         }
 
-        string[] groupsList = userInfo.groups is string[] ? <string[]>userInfo.groups : [<string>userInfo.groups];
         int[] privileges = [];
-        if authorization:checkPermissions([authorization:authorizedRoles.employeeRole], groupsList) {
+        if authorization:checkPermissions([authorization:authorizedRoles.employeeRole], userInfo.groups) {
             privileges.push(authorization:EMPLOYEE_ROLE_PRIVILEGE);
         }
-        if authorization:checkPermissions([authorization:authorizedRoles.financeAdminRole], groupsList) {
+        if authorization:checkPermissions([authorization:authorizedRoles.financeAdminRole], userInfo.groups) {
             privileges.push(authorization:FINANCE_ADMIN_PRIVILEGE);
         }
 
@@ -132,7 +131,7 @@ service http:InterceptableService / on new http:Listener(9090) {
     resource function get opd\-claims(http:RequestContext ctx, int? year = (), int? month = (), int months = 1)
         returns OpdClaimSummaryResponse|http:BadRequest|HttpInternalServerError {
 
-        authorization:CustomJwtPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        authorization:UserInfo|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
         if userInfo is error {
             return <http:BadRequest>{
                 body: {


### PR DESCRIPTION
### Problem
The JwtInterceptor was using `result[1].cloneWithType`(CustomJwtPayload) to extract email and groups from the decoded JWT. This caused a 500 Internal Server Error with the message "Malformed Invoker info object!" in staging because:

Ballerina's j`wt:decode()`stores custom claims (email, groups) in a rest field typed anydata
The groups claim arrives as json[] at runtime — cloneWithType cannot reliably convert anydata holding a json[] to string[]
If groups is absent entirely (user has no groups assigned), the required field has no default, causing an immediate conversion failure


### Fix
authorization.bal — Replaced cloneWithType(CustomJwtPayload) with:

- result[1].toJson() to convert the decoded payload to a plain map<json>
- Explicit type-guarded extraction of email (required) and groups (tolerates json[], bare string, or absent)
- types.bal — Added string[] groups = [] default to CustomJwtPayload as a safety net for any future usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize group claims into a consistent list for authorization checks.
  * Use the normalized group list when evaluating roles and permissions to avoid mismatches.
  * Default missing group information to an empty list to prevent runtime errors.
  * Preserve existing JWT/header error handling while improving robustness around group parsing.

* **Refactor**
  * Store normalized user info in request context for more reliable downstream authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->