### PR TITLE
Refactor backend configuration handling and replace sql:ConnectionPool with explicit config type

### DIFF
--- a/backend/modules/database/client.bal
+++ b/backend/modules/database/client.bal
@@ -16,14 +16,13 @@
 import ballerinax/mysql;
 import ballerinax/mysql.driver as _;
 
-configurable decimal connectTimeout = ?;
 configurable DatabaseConfig expenseDatabaseConfig = ?;
 
 final mysql:Options expenseDbOptions = {
     ssl: {
         mode: mysql:SSL_REQUIRED
     },
-    connectTimeout: connectTimeout
+    connectTimeout: expenseDatabaseConfig.connectTimeout
 };
 
 public final mysql:Client expenseDbClient = check new (
@@ -33,7 +32,11 @@ public final mysql:Client expenseDbClient = check new (
     expenseDatabaseConfig.database,
     expenseDatabaseConfig.port,
     expenseDbOptions,
-    expenseDatabaseConfig.connectionPool
+    {
+        maxOpenConnections: expenseDatabaseConfig.connectionPool.maxOpenConnections,
+        maxConnectionLifeTime: expenseDatabaseConfig.connectionPool.maxConnectionLifeTime,
+        minIdleConnections: expenseDatabaseConfig.connectionPool.minIdleConnections
+    }
 );
 
 # Check the health of the expense database.

--- a/backend/modules/database/types.bal
+++ b/backend/modules/database/types.bal
@@ -14,8 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/sql;
-
 # OPD claim status codes stored in the database.
 public enum OpdClaimStatus {
     OPD_CLAIM_STATUS_DELETED = "-1",
@@ -23,6 +21,12 @@ public enum OpdClaimStatus {
     OPD_CLAIM_STATUS_REJECTED = "1",
     OPD_CLAIM_STATUS_APPROVED = "3"
 }
+
+public type ConnectionPoolConfig record {|
+    int maxOpenConnections;
+    decimal maxConnectionLifeTime;
+    int minIdleConnections;
+|};
 
 # Configurable database connection settings.
 public type DatabaseConfig record {|
@@ -36,8 +40,10 @@ public type DatabaseConfig record {|
     string database;
     # Port used by the database server
     int port = 3306;
+    # Maximum time in seconds to wait when establishing a connection
+    decimal connectTimeout;
     # Connection pool settings for the database client
-    sql:ConnectionPool connectionPool = {};
+    ConnectionPoolConfig connectionPool;
 |};
 
 # Query result containing a single aggregated decimal total.

--- a/backend/opd_claim_summary.bal
+++ b/backend/opd_claim_summary.bal
@@ -133,18 +133,18 @@ public function getOpdClaimSummary(int year, int monthRange, int months = 1) ret
     int previousYearClaimCount = check database:queryClaimCount(year - 1);
     int gracePeriodClaims = check database:queryGracePeriodClaimCount(
         year,
-        lastYearClaimGracePeriodInDays
+        appConfig.lastYearClaimGracePeriodInDays
     );
     string[] allEmployeeEmails = check database:queryAllClaimEmployeeEmails();
     int totalEmployees = allEmployeeEmails.length();
     database:EmployeeTotalRow[] employeeTotals = check database:queryEmployeeTotals(year, monthRange, months);
 
     map<boolean> employeesWithClaimsSet = toEmployeesWithClaimsSet(employeeTotals);
-    int fullyClaimedEmployees = countFullyClaimedEmployees(employeeTotals, annualClaimLimit);
+    int fullyClaimedEmployees = countFullyClaimedEmployees(employeeTotals, appConfig.claimLimit);
     OpdClaimBucket[] activeClaimsChart = buildActiveClaimsChart(
         employeeTotals,
-        annualClaimLimit,
-        claimRangeStep
+        appConfig.claimLimit,
+        appConfig.claimRangeStep
     );
 
     int unclaimedEmployees = totalEmployees - employeesWithClaimsSet.length();

--- a/backend/opd_claim_summary.bal
+++ b/backend/opd_claim_summary.bal
@@ -128,6 +128,12 @@ isolated function buildActiveClaimsChart(database:EmployeeTotalRow[] employeeTot
 # + months - Number of months included in the reporting window
 # + return - OPD claim summary response if all queries succeed, otherwise an error
 public function getOpdClaimSummary(int year, int monthRange, int months = 1) returns OpdClaimSummaryResponse|error {
+    if appConfig.claimLimit <= 0d || appConfig.claimRangeStep <= 0d {
+        return error("Invalid appConfig: claimLimit and claimRangeStep must be greater than zero");
+    }
+    if appConfig.lastYearClaimGracePeriodInDays < 0 {
+        return error("Invalid appConfig: lastYearClaimGracePeriodInDays must be non-negative");
+    }
     decimal lastYearClaimAmount = check database:queryClaimAmount(year);
     decimal currentMonthClaimAmount = check database:queryClaimAmount(year, monthRange);
     int previousYearClaimCount = check database:queryClaimCount(year - 1);

--- a/backend/service.bal
+++ b/backend/service.bal
@@ -23,9 +23,6 @@ import ballerina/log;
 import ballerina/time;
 
 public configurable AppConfig appConfig = ?;
-configurable decimal annualClaimLimit = ?;
-configurable decimal claimRangeStep = ?;
-configurable int lastYearClaimGracePeriodInDays = ?;
 
 final cache:Cache cache = new ({
     capacity: 2000,

--- a/backend/types.bal
+++ b/backend/types.bal
@@ -38,13 +38,10 @@ public type UserInfoResponse record {|
 public type AppConfig record {|
     # Annual OPD claim limit per employee
     decimal claimLimit;
-
     # Allowed employee locations for claim submissions
     string[] submissionsAllowedLocations;
-
     # Step size used for OPD claim distribution chart buckets
     decimal claimRangeStep;
-
     # Number of days after year-end that prior-year claims are still accepted
     int lastYearClaimGracePeriodInDays;
 |};

--- a/backend/types.bal
+++ b/backend/types.bal
@@ -41,6 +41,12 @@ public type AppConfig record {|
 
     # Allowed employee locations for claim submissions
     string[] submissionsAllowedLocations;
+
+    # Step size used for OPD claim distribution chart buckets
+    decimal claimRangeStep;
+
+    # Number of days after year-end that prior-year claims are still accepted
+    int lastYearClaimGracePeriodInDays;
 |};
 
 # Claim distribution bucket used by OPD summary responses.


### PR DESCRIPTION

                                                                                                                 
###   Summary         

  - Replaced sql:ConnectionPool in DatabaseConfig with a custom ConnectionPoolConfig record (maxOpenConnections, 
  maxConnectionLifeTime, minIdleConnections), eliminating ~15 unused optional fields that were being surfaced
  unnecessarily in Choreo deployment configs.                                                                    
  - Moved connectTimeout into DatabaseConfig so all database settings are grouped under a single configurable.
  - Consolidated annualClaimLimit, claimRangeStep, and lastYearClaimGracePeriodInDays from top-level             
  configurables into AppConfig, removing duplication (annualClaimLimit was identical to appConfig.claimLimit).   
                                                                                                                 
###   Motivation                                                                                                     
                  
  Choreo was showing a large number of configuration fields due to sql:ConnectionPool exposing all its optional  
  fields, and several top-level configurables that were either duplicates or logically belonged inside AppConfig.
   This change reduces the Choreo config surface to only the fields that are actually required.                  
                                                                                               
  
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated multiple configuration parameters into a unified configuration object for simplified management.
  * Updated database connection handling to support configurable connection pool parameters for improved performance and resource management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/expense-management-app/pull/24)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->