### PR TITLE
Rename months to monthRange in frontend API params    

### DIFF
--- a/webapp/src/slices/expenseSlice/useEmployeeSpending.ts
+++ b/webapp/src/slices/expenseSlice/useEmployeeSpending.ts
@@ -51,7 +51,7 @@ export interface EmployeeCategoryTransactionItem {
 export interface DateRangeParams {
   year: string;
   month: string;
-  months: string;
+  monthRange: string;
 }
 
 export function resolveDateRangeParams(dateRange: string): DateRangeParams {
@@ -61,30 +61,30 @@ export function resolveDateRangeParams(dateRange: string): DateRangeParams {
 
   switch (dateRange) {
     case "All Time":
-      return { year: String(currentYear), month: String(currentMonth), months: "0" };
+      return { year: String(currentYear), month: String(currentMonth), monthRange: "0" };
     case "This Month":
-      return { year: String(currentYear), month: String(currentMonth), months: "1" };
+      return { year: String(currentYear), month: String(currentMonth), monthRange: "1" };
     case "Last Month": {
       const m = currentMonth === 1 ? 12 : currentMonth - 1;
       const y = currentMonth === 1 ? currentYear - 1 : currentYear;
-      return { year: String(y), month: String(m), months: "1" };
+      return { year: String(y), month: String(m), monthRange: "1" };
     }
     case "Last 3 Months":
-      return { year: String(currentYear), month: String(currentMonth), months: "3" };
+      return { year: String(currentYear), month: String(currentMonth), monthRange: "3" };
     case "Last 6 Months":
-      return { year: String(currentYear), month: String(currentMonth), months: "6" };
+      return { year: String(currentYear), month: String(currentMonth), monthRange: "6" };
     case "Last 9 Months":
-      return { year: String(currentYear), month: String(currentMonth), months: "9" };
+      return { year: String(currentYear), month: String(currentMonth), monthRange: "9" };
     case "Year to Date":
       return {
         year: String(currentYear),
         month: String(currentMonth),
-        months: String(currentMonth),
+        monthRange: String(currentMonth),
       };
     case "Last Year":
-      return { year: String(currentYear - 1), month: "12", months: "12" };
+      return { year: String(currentYear - 1), month: "12", monthRange: "12" };
     default:
-      return { year: String(currentYear), month: String(currentMonth), months: "0" };
+      return { year: String(currentYear), month: String(currentMonth), monthRange: "0" };
   }
 }
 
@@ -98,8 +98,8 @@ export function useEmployeeSpendingList(dateRange: string, businessUnit: string)
     setLoading(true);
     setError(null);
 
-    const { year, month, months } = resolveDateRangeParams(dateRange);
-    const params: Record<string, string> = { year, month, months };
+    const { year, month, monthRange } = resolveDateRangeParams(dateRange);
+    const params: Record<string, string> = { year, month, monthRange };
     if (businessUnit && businessUnit !== "All Business Units") {
       params.businessUnit = businessUnit;
     }
@@ -168,8 +168,8 @@ export function useEmployeeBreakdown(
     setError(null);
     setBreakdown(null);
 
-    const { year, month, months } = resolveDateRangeParams(dateRange);
-    const params: Record<string, string> = { email, year, month, months };
+    const { year, month, monthRange } = resolveDateRangeParams(dateRange);
+    const params: Record<string, string> = { email, year, month, monthRange };
     if (statusFilter && statusFilter !== "All") {
       params.statusFilter = statusFilter;
     }
@@ -250,8 +250,8 @@ export function useEmployeeCategoryTransactions(
       setLoading(true);
       setError(null);
 
-      const { year, month, months } = resolveDateRangeParams(dateRange);
-      const params: Record<string, string> = { email: emp, category: cat, year, month, months };
+      const { year, month, monthRange } = resolveDateRangeParams(dateRange);
+      const params: Record<string, string> = { email: emp, category: cat, year, month, monthRange };
       if (statusFilter && statusFilter !== "All") {
         params.statusFilter = statusFilter;
       }

--- a/webapp/src/slices/expenseSlice/useExpenseClaims.ts
+++ b/webapp/src/slices/expenseSlice/useExpenseClaims.ts
@@ -179,8 +179,8 @@ export const fetchExpenseClaims = createAsyncThunk<
   { rejectValue: string }
 >("expenseClaims/fetchExpenseClaims", async ({ filters }, { rejectWithValue }) => {
   try {
-    const { year, month, months } = resolveDateRangeParams(filters.dateRange);
-    const params: Record<string, string> = { year, month, months };
+    const { year, month, monthRange } = resolveDateRangeParams(filters.dateRange);
+    const params: Record<string, string> = { year, month, monthRange };
 
     if (filters.businessUnit && filters.businessUnit !== "All Business Units") {
       params.businessUnit = filters.businessUnit;

--- a/webapp/src/slices/expenseSlice/useLeadApprovalFrequency.ts
+++ b/webapp/src/slices/expenseSlice/useLeadApprovalFrequency.ts
@@ -126,8 +126,8 @@ export function useLeadFrequencyList(dateRange: string, businessUnit: string) {
     setLoading(true);
     setError(null);
 
-    const { year, month, months } = resolveDateRangeParams(dateRange);
-    const params: Record<string, string> = { year, month, months };
+    const { year, month, monthRange } = resolveDateRangeParams(dateRange);
+    const params: Record<string, string> = { year, month, monthRange };
     if (businessUnit && businessUnit !== "All Business Units") {
       params.businessUnit = businessUnit;
     }
@@ -186,11 +186,11 @@ export function useLeadApprovalDetail(email: string | null, dateRange: string) {
     setError(null);
     setDetail(null);
 
-    const { year, month, months } = resolveDateRangeParams(dateRange);
+    const { year, month, monthRange } = resolveDateRangeParams(dateRange);
 
     apiService
       .get<LeadApprovalDetail>("/lead-approval-detail", {
-        params: { email, year, month, months },
+        params: { email, year, month, monthRange },
       })
       .then((res) => {
         if (!cancelled && res.data) {

--- a/webapp/src/slices/opdSlice/useOpdClaims.ts
+++ b/webapp/src/slices/opdSlice/useOpdClaims.ts
@@ -160,7 +160,7 @@ export const fetchOpdClaims = createAsyncThunk<
       params.month = resolvedMonth;
     }
     if (resolvedMonths) {
-      params.months = resolvedMonths;
+      params.monthRange = resolvedMonths;
     }
 
     const response = await apiService.get<Partial<OpdClaimsData & BackendOpdClaimsData> | null>(


### PR DESCRIPTION
Frontend slices were sending months as the query parameter, but the backend reads monthRange after the earlier 
  rename. This caused the backend to always fall back to the default monthRange=1 (current month only), silently 
  ignoring the user-selected filter. Renamed the parameter across useEmployeeSpending, useExpenseClaims, 
  useLeadApprovalFrequency, and useOpdClaims to fix filter-driven data fetching.      

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated date-range parameter naming across expense tracking, claims, and approval features. The date-range filter now uses `monthRange` instead of `months` when communicating with backend endpoints for employee spending data, expense claims, lead approvals, and OPD claims.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/expense-management-app/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->