### PR TITLE
[Backend]: Refactor support methods out of service.bal

### DIFF
--- a/backend/service.bal
+++ b/backend/service.bal
@@ -15,12 +15,10 @@
 // under the License.
 import expense_management.authorization;
 import expense_management.database;
-import expense_management.entity;
 
 import ballerina/cache;
 import ballerina/http;
 import ballerina/log;
-import ballerina/time;
 
 public configurable AppConfig appConfig = ?;
 
@@ -29,116 +27,6 @@ final cache:Cache cache = new ({
     defaultMaxAge: CACHE_DEFAULT_MAX_AGE,
     cleanupInterval: CACHE_CLEANUP_INTERVAL
 });
-
-isolated function extractUserInfo(http:RequestContext ctx) returns authorization:UserInfo|http:BadRequest {
-    authorization:UserInfo|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
-    if userInfo is error {
-        return <http:BadRequest>{body: {message: "User information header not found!"}};
-    }
-    return userInfo;
-}
-
-isolated function resolveEffectiveDate(int? year, int? month) returns [int, int]|HttpInternalServerError {
-    time:Civil|error civilTime = time:utcToCivil(time:utcNow());
-    if civilTime is error {
-        log:printError("Failed to resolve current date.", civilTime);
-        return <HttpInternalServerError>{body: {message: "Failed to resolve the current date."}};
-    }
-    return [year ?: civilTime.year, month ?: civilTime.month];
-}
-
-isolated function normalizeBusinessUnit(string? businessUnit) returns string? {
-    if businessUnit is string &&
-            (businessUnit.trim().length() == 0 || businessUnit == "All Business Units") {
-        return ();
-    }
-    return businessUnit;
-}
-
-isolated function fetchNameMap(string[] emails) returns map<string> {
-    map<string>|error hrNames = entity:fetchEmployeeNameMap(emails);
-    return hrNames is map<string> ? hrNames : {};
-}
-
-isolated function validateDateParams(int? year, int? month, int monthRange) returns http:BadRequest? {
-    if year is int && (year < 1970 || year > 2100) {
-        return <http:BadRequest>{body: {message: "Invalid year. Expected a value between 1970 and 2100."}};
-    }
-    if month is int && (month < 1 || month > 12) {
-        return <http:BadRequest>{body: {message: "Invalid month. Expected a value between 1 and 12."}};
-    }
-    if monthRange < 0 || monthRange > 36 {
-        return <http:BadRequest>{body: {message: "monthRange must be between 0 and 36."}};
-    }
-    return ();
-}
-
-isolated function maskCardNumber(string cardNumber) returns string {
-    string digits = re `\D`.replaceAll(cardNumber, "");
-    if digits.length() < 4 {
-        return "**** **** **** ****";
-    }
-    string last4 = digits.substring(digits.length() - 4);
-    return string `**** **** **** ${last4}`;
-}
-
-function buildEffectiveAppConfig() returns AppConfig {
-    map<string>|error dbSettings = database:getAppSettings();
-    if dbSettings is error {
-        log:printWarn("Could not read app_settings from DB; using Config.toml defaults.", dbSettings);
-        return appConfig;
-    }
-
-    decimal claimLimit = appConfig.claimLimit;
-    decimal claimRangeStep = appConfig.claimRangeStep;
-    int lastYearClaimGracePeriodInDays = appConfig.lastYearClaimGracePeriodInDays;
-    string[] submissionsAllowedLocations = appConfig.submissionsAllowedLocations;
-
-    string? rawLimit = dbSettings["claimLimit"];
-    if rawLimit is string {
-        decimal|error v = decimal:fromString(rawLimit);
-        if v is decimal && v > 0.0d {
-            claimLimit = v;
-        } else {
-            log:printWarn("Ignoring invalid claimLimit from DB; keeping default.", val = rawLimit);
-        }
-    }
-
-    string? rawStep = dbSettings["claimRangeStep"];
-    if rawStep is string {
-        decimal|error v = decimal:fromString(rawStep);
-        if v is decimal && v > 0.0d {
-            claimRangeStep = v;
-        } else {
-            log:printWarn("Ignoring invalid claimRangeStep from DB; keeping default.", val = rawStep);
-        }
-    }
-
-    string? rawGrace = dbSettings["lastYearClaimGracePeriodInDays"];
-    if rawGrace is string {
-        int|error v = int:fromString(rawGrace);
-        if v is int && v >= 0 {
-            lastYearClaimGracePeriodInDays = v;
-        } else {
-            log:printWarn("Ignoring invalid lastYearClaimGracePeriodInDays from DB; keeping default.", val = rawGrace);
-        }
-    }
-
-    string? rawLocations = dbSettings["submissionsAllowedLocations"];
-    if rawLocations is string && rawLocations.length() > 0 {
-        string[] parsed = from string part in re `,`.split(rawLocations)
-            let string t = part.trim()
-            where t.length() > 0
-            select t;
-        if parsed.length() > 0 {
-            submissionsAllowedLocations = parsed;
-        } else {
-            log:printWarn("Ignoring empty submissionsAllowedLocations from DB; keeping default.", val = rawLocations);
-        }
-    }
-
-    return {claimLimit, claimRangeStep, lastYearClaimGracePeriodInDays, submissionsAllowedLocations};
-}
 
 service class ErrorInterceptor {
     *http:ResponseErrorInterceptor;

--- a/backend/utils.bal
+++ b/backend/utils.bal
@@ -13,6 +13,154 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import expense_management.authorization;
+import expense_management.database;
+import expense_management.entity;
+
+import ballerina/http;
+import ballerina/log;
+import ballerina/time;
+
+# Extract the authenticated user's info from the request context.
+#
+# + ctx - Request context populated by the JWT interceptor
+# + return - User info if present, otherwise a bad request response
+isolated function extractUserInfo(http:RequestContext ctx) returns authorization:UserInfo|http:BadRequest {
+    authorization:UserInfo|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+    if userInfo is error {
+        return <http:BadRequest>{body: {message: "User information header not found!"}};
+    }
+    return userInfo;
+}
+
+# Resolve the effective reporting year and month, defaulting unset values to the current date.
+#
+# + year - Optional reporting year
+# + month - Optional reporting month
+# + return - Effective [year, month] pair, or an error response if the current date cannot be resolved
+isolated function resolveEffectiveDate(int? year, int? month) returns [int, int]|HttpInternalServerError {
+    time:Civil|error civilTime = time:utcToCivil(time:utcNow());
+    if civilTime is error {
+        log:printError("Failed to resolve current date.", civilTime);
+        return <HttpInternalServerError>{body: {message: "Failed to resolve the current date."}};
+    }
+    return [year ?: civilTime.year, month ?: civilTime.month];
+}
+
+# Normalize a business unit filter, treating blank or "All Business Units" as unset.
+#
+# + businessUnit - Raw business unit filter value
+# + return - Normalized business unit, or () if the filter should be treated as unset
+isolated function normalizeBusinessUnit(string? businessUnit) returns string? {
+    if businessUnit is string &&
+            (businessUnit.trim().length() == 0 || businessUnit == "All Business Units") {
+        return ();
+    }
+    return businessUnit;
+}
+
+# Look up display names for a set of employee emails, falling back to an empty map on failure.
+#
+# + emails - Employee email addresses to resolve
+# + return - Map of lower-cased email to display name
+isolated function fetchNameMap(string[] emails) returns map<string> {
+    map<string>|error hrNames = entity:fetchEmployeeNameMap(emails);
+    return hrNames is map<string> ? hrNames : {};
+}
+
+# Validate common year/month/monthRange query parameters shared across reporting endpoints.
+#
+# + year - Optional reporting year
+# + month - Optional reporting month
+# + monthRange - Number of months included in the reporting window
+# + return - Bad request response if any parameter is invalid, otherwise ()
+isolated function validateDateParams(int? year, int? month, int monthRange) returns http:BadRequest? {
+    if year is int && (year < 1970 || year > 2100) {
+        return <http:BadRequest>{body: {message: "Invalid year. Expected a value between 1970 and 2100."}};
+    }
+    if month is int && (month < 1 || month > 12) {
+        return <http:BadRequest>{body: {message: "Invalid month. Expected a value between 1 and 12."}};
+    }
+    if monthRange < 0 || monthRange > 36 {
+        return <http:BadRequest>{body: {message: "monthRange must be between 0 and 36."}};
+    }
+    return ();
+}
+
+# Mask a credit card number, keeping only the last 4 digits visible.
+#
+# + cardNumber - Raw card number, possibly containing separators
+# + return - Masked card number in "**** **** **** 1234" form
+isolated function maskCardNumber(string cardNumber) returns string {
+    string digits = re `\D`.replaceAll(cardNumber, "");
+    if digits.length() < 4 {
+        return "**** **** **** ****";
+    }
+    string last4 = digits.substring(digits.length() - 4);
+    return string `**** **** **** ${last4}`;
+}
+
+# Build the effective application configuration, applying any admin overrides stored in the database
+# on top of the Config.toml defaults.
+#
+# + return - Effective application configuration
+function buildEffectiveAppConfig() returns AppConfig {
+    map<string>|error dbSettings = database:getAppSettings();
+    if dbSettings is error {
+        log:printWarn("Could not read app_settings from DB; using Config.toml defaults.", dbSettings);
+        return appConfig;
+    }
+
+    decimal claimLimit = appConfig.claimLimit;
+    decimal claimRangeStep = appConfig.claimRangeStep;
+    int lastYearClaimGracePeriodInDays = appConfig.lastYearClaimGracePeriodInDays;
+    string[] submissionsAllowedLocations = appConfig.submissionsAllowedLocations;
+
+    string? rawLimit = dbSettings["claimLimit"];
+    if rawLimit is string {
+        decimal|error v = decimal:fromString(rawLimit);
+        if v is decimal && v > 0.0d {
+            claimLimit = v;
+        } else {
+            log:printWarn("Ignoring invalid claimLimit from DB; keeping default.", val = rawLimit);
+        }
+    }
+
+    string? rawStep = dbSettings["claimRangeStep"];
+    if rawStep is string {
+        decimal|error v = decimal:fromString(rawStep);
+        if v is decimal && v > 0.0d {
+            claimRangeStep = v;
+        } else {
+            log:printWarn("Ignoring invalid claimRangeStep from DB; keeping default.", val = rawStep);
+        }
+    }
+
+    string? rawGrace = dbSettings["lastYearClaimGracePeriodInDays"];
+    if rawGrace is string {
+        int|error v = int:fromString(rawGrace);
+        if v is int && v >= 0 {
+            lastYearClaimGracePeriodInDays = v;
+        } else {
+            log:printWarn("Ignoring invalid lastYearClaimGracePeriodInDays from DB; keeping default.", val = rawGrace);
+        }
+    }
+
+    string? rawLocations = dbSettings["submissionsAllowedLocations"];
+    if rawLocations is string && rawLocations.length() > 0 {
+        string[] parsed = from string part in re `,`.split(rawLocations)
+            let string t = part.trim()
+            where t.length() > 0
+            select t;
+        if parsed.length() > 0 {
+            submissionsAllowedLocations = parsed;
+        } else {
+            log:printWarn("Ignoring empty submissionsAllowedLocations from DB; keeping default.", val = rawLocations);
+        }
+    }
+
+    return {claimLimit, claimRangeStep, lastYearClaimGracePeriodInDays, submissionsAllowedLocations};
+}
 
 # Derive a human-readable display name from an email address.
 #
@@ -80,7 +228,6 @@ isolated function getMainCategory(string expenseType) returns string {
     return expenseType;
 }
 
-
 # Split a comma-separated email field into individual trimmed email addresses.
 # Handles the case where lead_email stores multiple approvers as "a@x.com,b@x.com".
 #
@@ -88,7 +235,7 @@ isolated function getMainCategory(string expenseType) returns string {
 # + return - Array of individual trimmed email addresses, excluding empty strings
 isolated function splitEmails(string emailField) returns string[] {
     string[] emails = [];
-    foreach string part in re`,`.split(emailField) {
+    foreach string part in re `,`.split(emailField) {
         string trimmed = part.trim();
         if trimmed.length() > 0 {
             emails.push(trimmed);


### PR DESCRIPTION
# Purpose
Closes #40.

`backend/service.bal` mixed HTTP service resources/configurable definitions with reusable helper logic — date validation/resolution, business-unit normalization, name lookups, card masking, and effective app-config building. This made the file harder to navigate and the helpers awkward to reuse independently of the service resources.

# Goals
- Move non-resource, non-configurable helpers out of `service.bal` into `backend/utils.bal`.
- Keep `service.bal` limited to configurables, `ErrorInterceptor`, and the HTTP service class/resources.
- Preserve existing behavior exactly, including CC date param validation.

# Approach
Backend-only, 2 files: `service.bal`, `utils.bal`. Moved `extractUserInfo`, `resolveEffectiveDate`, `normalizeBusinessUnit`, `fetchNameMap`, `validateDateParams`, `maskCardNumber`, `buildEffectiveAppConfig` verbatim to `utils.bal`, which picked up the `authorization`/`database`/`entity`/`http`/`log`/`time` imports they need. Dropped now-unused `entity`/`time` imports from `service.bal`. Same default module on both sides, so no import qualification was needed at call sites. Pure code move — no logic changed.

# Release note
No user-facing change. Internal refactor: backend helpers moved from `service.bal` to `utils.bal`.

# Security checks
- Secure coding standards followed: yes
- FindSecurityBugs: N/A (pure code move)
- No secrets committed: yes

# Test environment
`bal format` + `bal build` locally (macOS) — compiles clean, only pre-existing non-isolated-method `HINT`s.

# Test plan
- [x] `bal build` compiles without errors
- [ ] Existing endpoints behave identically
- [ ] CC date param validation rejects invalid year/month/monthRange as before


# Learning
`service.bal` and `utils.bal` share the same default module, so no import qualification was needed on the calling side — only `utils.bal` needed new imports for the helpers' own dependencies.
